### PR TITLE
Characteristics count bug fix and battery service

### DIFF
--- a/lib/arduino-BLEPeripheral/src/nRF51822.cpp
+++ b/lib/arduino-BLEPeripheral/src/nRF51822.cpp
@@ -245,7 +245,7 @@ void nRF51822::begin(unsigned char advertisementDataSize,
     }
   }
 
-  this->_numLocalCharacteristics -= 3; // 0x2a00, 0x2a01, 0x2a05
+  this->_numLocalCharacteristics -= 2; // 0x2a00, 0x2a01, 0x2a05
 
   this->_localCharacteristicInfo = (struct localCharacteristicInfo*)malloc(sizeof(struct localCharacteristicInfo) * this->_numLocalCharacteristics);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -251,7 +251,6 @@ void setup() {
   blePeripheral.addAttribute(buttonCharacteristic);
   blePeripheral.addAttribute(iphoneCharacteristic);
   
-  blePeripheral.setAdvertisedServiceUuid(batteryService.uuid());
   blePeripheral.addAttribute(batteryService);
   blePeripheral.addAttribute(batteryLevel);
 


### PR DESCRIPTION
Hi,

You commented out servicesChangedCharacteristic (0x2a05) from BLEPeripheral. There was a corresponding code that for some reason subtracted this and 2 other services from internal counter. This resulted in the last user added characteristic being ignored by the library, it was not updated on "setValue" call.

I also uncommented the battery service, and implemented nonlinear approximation of the battery level. All seams to work as expected.